### PR TITLE
AMF: fix Qiu Jing's name

### DIFF
--- a/taskgroups/AMF.md
+++ b/taskgroups/AMF.md
@@ -22,7 +22,7 @@ The resulting specification will encompass:
 - a review of the interactions of matrix load/store and prefetching of matrices with the RISC-V memory models and a specification of any deviations from the standard RISC-V memory model.
 
 ## Acting leadership
-- Chou Jing (T-Head)
+- Qiu Jing (Alibaba)
 - Philipp Tomsich (VRULL)
 
 ## Proposed workplan

--- a/taskgroups/AMF.md
+++ b/taskgroups/AMF.md
@@ -1,5 +1,7 @@
 # Task Group: Attached Matrix Facility
 
+Please refer to https://github.com/riscv-admin/attached-matrix-facility/blob/main/charter.adoc for the most up-to-date group charter.
+
 ## Proposed charter
 Matrix operations are a key operation in deep-learning training and inference for workloads like natural-language processing, recommendation systems, and image recognition.  With the pervasive use of these applications in environments ranging from the datacenter, through IoT to mobile applications, matrix operations for RISC-V should scale across these application domains and apply to high-performance and resource-constrained environments.
 


### PR DESCRIPTION
Fix Qiu Jing's name (Qiu is the family name, Jing is the given name).